### PR TITLE
fix: matching logic fix for test in diff files

### DIFF
--- a/src/api/log_parser.rs
+++ b/src/api/log_parser.rs
@@ -8,29 +8,124 @@ use crate::api::rust_log_parser::RustLogParser;
 use crate::app::types::{TestStatus, LogAnalysisResult, RuleViolations, RuleViolation, DebugInfo, LogCount};
 
 // Helper function to check if diff content contains an exact test name
+// This function performs precise matching to avoid false positives from substring matches
 fn contains_exact_test_name(diff_content: &str, test_name: &str) -> bool {
+    use regex::Regex;
+    use lazy_static::lazy_static;
+    
+    lazy_static! {
+        // Enhanced regex to match various function declaration formats
+        static ref FUNCTION_DECLARATION_RE: Regex = Regex::new(
+            r"(?m)^\s*(?:#\[[^\]]*\]\s*)*(?:pub\s+)?(?:async\s+)?(?:unsafe\s+)?fn\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:<[^>]*>)?\s*\("
+        ).unwrap();
+        
+        // Regex to match test attribute annotations
+        static ref TEST_ATTRIBUTE_RE: Regex = Regex::new(
+            r"(?m)^\s*#\[test\]\s*(?:\n\s*)*(?:#\[[^\]]*\]\s*)*(?:pub\s+)?(?:async\s+)?(?:unsafe\s+)?fn\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*"
+        ).unwrap();
+        
+        // Regex to match mod declarations (for module path matching)
+        static ref MOD_DECLARATION_RE: Regex = Regex::new(
+            r"(?m)^\s*(?:pub\s+)?mod\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*[{;]"
+        ).unwrap();
+    }
+    
     // Split the test name to handle module paths like "test_module::test_function"
     let test_parts: Vec<&str> = test_name.split("::").collect();
     let function_name = test_parts.last().unwrap_or(&test_name);
     
-    // Look for exact matches in various test declaration patterns
-    let patterns = [
-        format!("fn {}(", function_name),           // fn test_name(
-        format!("fn {} (", function_name),          // fn test_name (
-        format!("fn {}\n", function_name),          // fn test_name\n
-        format!("fn {}\r", function_name),          // fn test_name\r
-        format!("fn {}\t", function_name),          // fn test_name\t  
-        format!("fn {}{{", function_name),          // fn test_name{
-        format!("async fn {}(", function_name),     // async fn test_name(
-        format!("async fn {} (", function_name),    // async fn test_name (
-    ];
+    // 1. Check for exact function name matches in function declarations
+    for caps in FUNCTION_DECLARATION_RE.captures_iter(diff_content) {
+        if let Some(found_fn_name) = caps.get(1) {
+            if found_fn_name.as_str() == *function_name {
+                return true;
+            }
+        }
+    }
     
-    patterns.iter().any(|pattern| diff_content.contains(pattern)) ||
-    // Also check for the full test name in test declarations
-    diff_content.contains(&format!("fn {}(", test_name)) ||
-    diff_content.contains(&format!("fn {} (", test_name)) ||
-    diff_content.contains(&format!("async fn {}(", test_name)) ||
-    diff_content.contains(&format!("async fn {} (", test_name))
+    // 2. Check for test attribute with matching function name
+    for caps in TEST_ATTRIBUTE_RE.captures_iter(diff_content) {
+        if let Some(found_fn_name) = caps.get(1) {
+            if found_fn_name.as_str() == *function_name {
+                return true;
+            }
+        }
+    }
+    
+    // 3. For module paths, check if the full path exists
+    if test_name.contains("::") {
+        // Try to match the full module path
+        let escaped_test_name = regex::escape(test_name);
+        let full_path_regex = Regex::new(&format!(
+            r"(?m)^\s*(?:#\[[^\]]*\]\s*)*(?:pub\s+)?(?:async\s+)?(?:unsafe\s+)?fn\s+{}\s*(?:<[^>]*>)?\s*\(",
+            escaped_test_name
+        )).unwrap_or_else(|_| Regex::new(r"$^").unwrap()); // fallback to never-matching regex
+        
+        if full_path_regex.is_match(diff_content) {
+            return true;
+        }
+        
+        // Also check for the module path structure
+        let module_parts = &test_parts[..test_parts.len().saturating_sub(1)];
+        if !module_parts.is_empty() {
+            let mut found_all_modules = true;
+            for module in module_parts {
+                let module_regex = Regex::new(&format!(
+                    r"(?m)^\s*(?:pub\s+)?mod\s+{}\s*[{{;]",
+                    regex::escape(module)
+                )).unwrap_or_else(|_| Regex::new(r"$^").unwrap());
+                
+                if !module_regex.is_match(diff_content) {
+                    found_all_modules = false;
+                    break;
+                }
+            }
+            
+            // If we found all modules and the function, it's a match
+            if found_all_modules {
+                let function_in_module_regex = Regex::new(&format!(
+                    r"(?m)^\s*(?:#\[[^\]]*\]\s*)*(?:pub\s+)?(?:async\s+)?(?:unsafe\s+)?fn\s+{}\s*(?:<[^>]*>)?\s*\(",
+                    regex::escape(function_name)
+                )).unwrap_or_else(|_| Regex::new(r"$^").unwrap());
+                
+                if function_in_module_regex.is_match(diff_content) {
+                    return true;
+                }
+            }
+        }
+    }
+    
+    // 4. Additional check for word boundaries to ensure exact matches
+    // This prevents partial matches like "test_foo" matching "test_foobar"
+    let word_boundary_regex = Regex::new(&format!(
+        r"\b{}\b",
+        regex::escape(function_name)
+    )).unwrap_or_else(|_| Regex::new(r"$^").unwrap());
+    
+    // Only consider it a match if it appears in a function context
+    let lines: Vec<&str> = diff_content.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if word_boundary_regex.is_match(line) {
+            // Check if this line or nearby lines contain function declaration keywords
+            let context_start = i.saturating_sub(2);
+            let context_end = (i + 3).min(lines.len());
+            let context = lines[context_start..context_end].join("\n");
+            
+            if context.contains("fn ") || context.contains("#[test]") || context.contains("mod ") {
+                // Verify it's actually a function declaration, not just a reference
+                let fn_declaration_regex = Regex::new(&format!(
+                    r"(?m)^\s*(?:#\[[^\]]*\]\s*)*(?:pub\s+)?(?:async\s+)?(?:unsafe\s+)?fn\s+{}\s*(?:<[^>]*>)?\s*\(",
+                    regex::escape(function_name)
+                )).unwrap_or_else(|_| Regex::new(r"$^").unwrap());
+                
+                if fn_declaration_regex.is_match(&context) {
+                    return true;
+                }
+            }
+        }
+    }
+    
+    false
 }
 
 // Trait for language-specific log parsers

--- a/src/app/deliverable_checker_interface.rs
+++ b/src/app/deliverable_checker_interface.rs
@@ -115,7 +115,17 @@ pub fn DeliverableCheckerInterface(
                 }
                 
                 if test_type == "fail_to_pass" && rule_checks.c7_f2p_tests_in_golden_source_diff.has_problem {
-                    if rule_checks.c7_f2p_tests_in_golden_source_diff.examples.iter().any(|example| example.contains(&test_name)) {
+                    let matches = rule_checks.c7_f2p_tests_in_golden_source_diff.examples.iter()
+                        .any(|example| {
+                            // C7 examples have format: "test_name (found as 'function_name' in file but not in test diffs)"
+                            // Extract the test name before the first " (" to get exact match
+                            if let Some(test_part) = example.split(" (").next() {
+                                test_part == test_name
+                            } else {
+                                example == &test_name
+                            }
+                        });
+                    if matches {
                         violated_rules.push(RuleViolationInfo {
                             rule_name: "c7_f2p_tests_in_golden_source_diff".to_string(),
                             description: "Fail-to-pass tests present in golden source diff".to_string(),

--- a/src/app/processing.rs
+++ b/src/app/processing.rs
@@ -6,14 +6,20 @@ use std::collections::HashMap;
 #[server]
 pub async fn handle_validate_deliverable(deliverable_link: String) -> Result<ValidationResult, ServerFnError> {
     use crate::api::deliverable::{validate_deliverable_impl};
-    Ok(validate_deliverable_impl(deliverable_link).await.unwrap())
+    match validate_deliverable_impl(deliverable_link).await {
+        Ok(result) => Ok(result),
+        Err(e) => Err(ServerFnError::ServerError(format!("Failed to validate deliverable: {}", e)))
+    }
 }
 
 
 #[server]
 pub async fn handle_download_deliverable(files_to_download: Vec<FileInfo>, folder_id: String) -> Result<DownloadResult, ServerFnError> {
     use crate::api::deliverable::{download_deliverable_impl};
-    Ok(download_deliverable_impl(files_to_download, folder_id).await.unwrap())
+    match download_deliverable_impl(files_to_download, folder_id).await {
+        Ok(result) => Ok(result),
+        Err(e) => Err(ServerFnError::ServerError(format!("Failed to download deliverable: {}", e)))
+    }
 }
 
 

--- a/src/app/test_checker.rs
+++ b/src/app/test_checker.rs
@@ -163,7 +163,15 @@ pub fn TestChecker(
             // C7: F2P tests in golden source diff
             if test_type == "fail_to_pass" && rule_checks.c7_f2p_tests_in_golden_source_diff.has_problem {
                 let matches = rule_checks.c7_f2p_tests_in_golden_source_diff.examples.iter()
-                    .any(|example| example.contains(test_name));
+                    .any(|example| {
+                        // C7 examples have format: "test_name (found as 'function_name' in file but not in test diffs)"
+                        // Extract the test name before the first " (" to get exact match
+                        if let Some(test_part) = example.split(" (").next() {
+                            test_part == test_name
+                        } else {
+                            example == test_name
+                        }
+                    });
                 if matches {
                     violated_rules.push(RuleViolationInfo::new(
                         "c7_f2p_tests_in_golden_source_diff",


### PR DESCRIPTION
Previously we were allowing fuzzy matching that was causing false positives and this was causing confusions. Now we are doing exact test name matching. 